### PR TITLE
fix PROFILE_INFO Dict to match new data format

### DIFF
--- a/OnlySnap.py
+++ b/OnlySnap.py
@@ -999,7 +999,7 @@ while True:
                 "id": PROFILE_INFO["id"],
                 "name": PROFILE_INFO["name"],
                 "username": PROFILE_INFO["username"],
-                "about": PROFILE_INFO["rawAbout"],
+                "about": PROFILE_INFO["about"],
                 "joinDate": PROFILE_INFO["joinDate"],
                 "website": PROFILE_INFO["website"],
                 "wishlist": PROFILE_INFO["wishlist"],


### PR DESCRIPTION
This fixes an error while getting profile info which made the scrapper unusable, it looks like Onlyfans change their rawAbout key to about, making a breaking bug on the script.